### PR TITLE
fix: ログアウト後にGoogleログインを実行するとcurrentUserがnullになる #89

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -43,9 +43,4 @@ server {
     proxy_set_header Host $http_host;
     proxy_pass http://api;
   }
-
-  # リバースプロキシ関連の設定(サードパーティのストレージアクセスをブロックするブラウザで signInWithRedirectを使用するための設定)
-  location /__/auth {
-    proxy_pass https://hayabusatrip-825fa.firebaseapp.com;
-  }
 }


### PR DESCRIPTION
close #89 