### PR TITLE
feat: 日付指定でspotAPI#destroyが実行された場合に、削除対象がなくても:no_contentを返却するように修正 #96

### DIFF
--- a/app/controllers/api/v1/spots_controller.rb
+++ b/app/controllers/api/v1/spots_controller.rb
@@ -49,15 +49,16 @@ module Api
       def destroy
         if params[:date]
           @spots = @trip.spots.where(date: params[:date])
-        else
-          @spots = @trip.spots.where(id: params[:id])
-        end
-
-        if @spots.exists?
-          @spots.destroy_all
+          @spots.destroy_all if @spots.exists?
           head :no_content
         else
-          render json: { error: { messages: ["指定した旅行スポットが存在しません。"] } }, status: :not_found
+          @spots = @trip.spots.where(id: params[:id])
+          if @spots.exists?
+            @spots.destroy_all
+            head :no_content
+          else
+            render json: { error: { messages: ["指定した旅行スポットが存在しません。"] } }, status: :not_found
+          end
         end
       end
 

--- a/spec/controllers/api/v1/spots_controller_spec.rb
+++ b/spec/controllers/api/v1/spots_controller_spec.rb
@@ -188,16 +188,27 @@ RSpec.describe Api::V1::SpotsController do
       it "does not destroy any spot" do
         expect {
           delete :destroy,
-                 params: { user_uid: user.uid, trip_trip_token: trip.trip_token, id: "nonexistent_id",
-                           date: Time.zone.yesterday }
+                 params: { user_uid: user.uid, trip_trip_token: trip.trip_token, id: "nonexistent_id" }
         }.not_to change(Spot, :count)
       end
 
       it "returns not found" do
         delete :destroy,
-               params: { user_uid: user.uid, trip_trip_token: trip.trip_token, id: "nonexistent_id",
-                         date: Time.zone.yesterday }
+               params: { user_uid: user.uid, trip_trip_token: trip.trip_token, id: "nonexistent_id" }
         expect(response).to have_http_status(:not_found)
+      end
+
+      it "does not destroy any spot when the date does not exist" do
+        expect {
+          delete :destroy,
+                 params: { user_uid: user.uid, trip_trip_token: trip.trip_token, date: Time.zone.yesterday }
+        }.not_to change(Spot, :count)
+      end
+
+      it "returns no content when the date does not exist" do
+        delete :destroy,
+               params: { user_uid: user.uid, trip_trip_token: trip.trip_token, date: Time.zone.yesterday }
+        expect(response).to have_http_status(:no_content)
       end
     end
   end


### PR DESCRIPTION
close #96 