### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI/CD
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/keynyaan/hayabusatrip-backend/security/code-scanning/4](https://github.com/keynyaan/hayabusatrip-backend/security/code-scanning/4)

To fix the problem, you should add a `permissions` block to the workflow to explicitly limit the permissions granted to the `GITHUB_TOKEN`. The best practice is to set `permissions: contents: read` at the top level of the workflow, which restricts most jobs to only the minimum required permission (read access to repository contents). If any specific jobs require elevated permissions (e.g., to create releases or interact with issues or pull requests), you can override the `permissions` block inside that job. 

For this workflow file `.github/workflows/ci.yml`, add the following block after the `name` and before `on` (line 2):

```yaml
permissions:
  contents: read
```

This applies the minimal required permissions to all jobs unless specifically overridden. No other code or external dependencies are needed, as this is entirely a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
